### PR TITLE
feat: add release-please for automated releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,22 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          release-type: elixir


### PR DESCRIPTION
## Summary

Adds release-please workflow for fully automated releases.

### How it works

1. Push commits to main using conventional commit format (`feat:`, `fix:`, etc.)
2. Release-please automatically creates/updates a release PR with:
   - Changelog generated from commits
   - Version bump in mix.exs
3. When you merge the release PR:
   - Release-please creates a GitHub release with `v*` tag
   - **precompile.yml** triggers, builds NIFs, attaches to release
   - **hex-publish.yml** triggers, publishes to hex.pm

### Conventional commits cheat sheet

- `feat:` - new feature (minor version bump)
- `fix:` - bug fix (patch version bump)
- `feat!:` or `fix!:` - breaking change (minor bump for 0.x)
- `docs:`, `chore:`, `refactor:` - no version bump